### PR TITLE
fix(x/staking): remove duplicate updates

### DIFF
--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -273,6 +273,8 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 	default: // equal amounts of tokens; no update required
 	}
 
+	updates = deDuplicateValUpdates(updates)
+
 	// set total power on lookup index if there are any updates
 	if len(updates) > 0 {
 		if err = k.SetLastTotalPower(ctx, totalPower); err != nil {
@@ -286,6 +288,22 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 	}
 
 	return updates, err
+}
+
+func deDuplicateValUpdates(updates []abci.ValidatorUpdate) []abci.ValidatorUpdate {
+	var uniqueUpdates []abci.ValidatorUpdate
+
+	for _, update := range updates {
+		for i, uniqueUpdate := range uniqueUpdates {
+			if bytes.Equal(update.PubKeyBytes, uniqueUpdate.PubKeyBytes) {
+				uniqueUpdates[i] = update
+				continue
+			}
+		}
+		uniqueUpdates = append(uniqueUpdates, update)
+	}
+
+	return uniqueUpdates
 }
 
 // Validator state transitions

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"maps"
-	"slices"
 	"sort"
 
 	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
@@ -165,7 +163,6 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 		return nil, err
 	}
 	defer iterator.Close()
-	updatesMap := make(map[string]abci.ValidatorUpdate)
 
 	count := 0
 	for ; iterator.Valid() && count < int(maxValidators); iterator.Next() {
@@ -216,7 +213,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 
 		// update the validator set if power has changed
 		if !found || !bytes.Equal(oldPowerBytes, newPowerBytes) {
-			updatesMap[valAddr.String()] = validator.ABCIValidatorUpdate(powerReduction)
+			updates = append(updates, validator.ABCIValidatorUpdate(powerReduction))
 
 			if err = k.SetLastValidatorPower(ctx, valAddr, newPower); err != nil {
 				return nil, err
@@ -254,7 +251,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 			return nil, err
 		}
 
-		updatesMap[validator.OperatorAddress] = validator.ABCIValidatorUpdateZero()
+		updates = append(updates, validator.ABCIValidatorUpdateZero())
 	}
 
 	// Update the pools based on the recent updates in the validator set:
@@ -275,8 +272,6 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 		}
 	default: // equal amounts of tokens; no update required
 	}
-
-	updates = slices.Collect(maps.Values(updatesMap))
 
 	// set total power on lookup index if there are any updates
 	if len(updates) > 0 {

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -273,7 +273,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 	default: // equal amounts of tokens; no update required
 	}
 
-	updates = deDuplicateValUpdates(updates)
+	updates = DeDuplicateValUpdates(updates)
 
 	// set total power on lookup index if there are any updates
 	if len(updates) > 0 {
@@ -290,14 +290,15 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 	return updates, err
 }
 
-func deDuplicateValUpdates(updates []abci.ValidatorUpdate) []abci.ValidatorUpdate {
+func DeDuplicateValUpdates(updates []abci.ValidatorUpdate) []abci.ValidatorUpdate {
 	var uniqueUpdates []abci.ValidatorUpdate
 
+outer:
 	for _, update := range updates {
 		for i, uniqueUpdate := range uniqueUpdates {
 			if bytes.Equal(update.PubKeyBytes, uniqueUpdate.PubKeyBytes) {
 				uniqueUpdates[i] = update
-				continue
+				continue outer
 			}
 		}
 		uniqueUpdates = append(uniqueUpdates, update)

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"bytes"
 	"time"
 
 	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
@@ -439,4 +440,48 @@ func (s *KeeperTestSuite) TestUnbondingValidator() {
 	validator, err = keeper.GetValidator(ctx, valAddr)
 	require.NoError(err)
 	require.Equal(stakingtypes.Unbonded, validator.Status)
+}
+
+func (s *KeeperTestSuite) Test_DeDuplicateValUpdates() {
+	require := s.Require()
+
+	var updates = []abci.ValidatorUpdate{
+		{
+			Power:       1000000,
+			PubKeyBytes: []byte("0xBYTEBYTE"),
+			PubKeyType:  "type",
+		},
+		{
+			Power:       1000000,
+			PubKeyBytes: []byte("0xCAFECODE"),
+			PubKeyType:  "type",
+		},
+		{
+			Power:       1000000,
+			PubKeyBytes: []byte("0xCAFECODE"),
+			PubKeyType:  "type",
+		},
+		{
+			Power:       1000000,
+			PubKeyBytes: []byte("0xCAFECODE"),
+			PubKeyType:  "type",
+		},
+		{
+			Power:       1000000,
+			PubKeyBytes: []byte("0xDEADCODE"),
+			PubKeyType:  "type",
+		},
+		{
+			Power:       1000000,
+			PubKeyBytes: []byte("0xCAFECODE"),
+			PubKeyType:  "type",
+		},
+	}
+
+	unique := stakingkeeper.DeDuplicateValUpdates(updates)
+
+	require.Equal(3, len(unique))
+	require.True(bytes.Equal(unique[0].PubKeyBytes, []byte("0xBYTEBYTE")))
+	require.True(bytes.Equal(unique[1].PubKeyBytes, []byte("0xCAFECODE")))
+	require.True(bytes.Equal(unique[2].PubKeyBytes, []byte("0xDEADCODE")))
 }


### PR DESCRIPTION
De-duplicates the validator updates while preserving order
Consequences:
- only maintains the most recent update